### PR TITLE
fix _track_routes method in case the router without filter path.

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,8 @@ function _track_routes(file, path, handle) {
     // console.log(_route);
     // console.log(_route.stack);
     // console.log(_route.methods);
+    if(!_route)continue;  //添加了非空的处理逻辑，挂载中间件的路由不予显示在路由列表中
+
     var params = _route.stack.params;
     
     for(var j in _route.methods){


### PR DESCRIPTION
Hi,桑老师：

自动挂载路由的这个模块非常好用，方便我设计结构化的 API 接口，今天我在路由中使用中间件的过程中，发现模块中的路由生成方法报错，原因是使用 router.use 添加中间件的方法中没有 stack 属性，导致 路由地址导出方法 `_track_routes` 抛出异常。

本想fork后发一个 PR 给您，但是我发现 github 中的源码与 npm 安装后的源码版本不一样。所以就新建了一个 issues 

我的路由代码如下

router.js

``` javascript

//引入中间件
var $m = require('mount-middlewares')(__dirname).check_api_token;

//添加了token的认证，该路由下的所有API 请求都需要进行token
router.use($m);


```

修改后的 `mount-routes`代码如下  49行开始
index.js

``` javascript

function _track_routes(file, path, handle) {
  for(var i in handle){
    var _route = handle[i].route;
    // console.log(_route);
    // console.log(_route.stack);
    // console.log(_route.methods);
    if(!_route)continue;  //添加了非空的处理逻辑，挂载中间件的路由不予显示在路由列表中
    var params = _route.stack.params;

    for(var j in _route.methods){
      if(_route.path == '/'){
        _cache_to_stack(file, path, j);
      }else{
        _cache_to_stack(file, path + _route.path, j);
      }
    }
  }
}

```
